### PR TITLE
TextWrangler v5.0

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@
 #   include textwrangler
 class textwrangler {
   package { 'TextWrangler':
-    source   => 'http://ash.barebones.com/TextWrangler_4.5.8.dmg',
+    source   => 'https://s3.amazonaws.com/BBSW-download/TextWrangler_5.0.dmg',
     provider => 'appdmg'
   }
 }

--- a/spec/classes/textwrangler_spec.rb
+++ b/spec/classes/textwrangler_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'textwrangler' do
   it do
     should contain_package('TextWrangler').with({
-      :source   => 'http://ash.barebones.com/TextWrangler_4.5.8.dmg',
+      :source   => 'https://s3.amazonaws.com/BBSW-download/TextWrangler_5.0.dmg',
       :provider => 'appdmg'
     })
   end


### PR DESCRIPTION
Altered URI reference from 4.5.8 to 5.0

The origin URI for 4.5.8 was a dead link.